### PR TITLE
Fix stage script default repo

### DIFF
--- a/script/stage
+++ b/script/stage
@@ -8,14 +8,14 @@ account='training-staging'
 
 if [ "$1" = "" ]
 then
-  repo="caption-this"
+  repo=$(basename "$(git config --get remote.origin.url)" .git)
 else
   repo=$1
 fi
 
 # Build the site
 #
-# Generate the Jekyll site with an alterate baseurl for the intenral-only
+# Generate the Jekyll site with an alternate baseurl for the internal-only
 # staging site, but don't start a local server.
 printf "\n${grn}# Building site...\n--------------------------------------------------${end}\n"
 DISABLE_WHITELIST=1 bundle exec jekyll build --baseurl "/${account}/${repo}"


### PR DESCRIPTION
## Summary
- fix incorrect default repo in `script/stage`
- clean up comment typos
- use current repo automatically

## Testing
- `apt-get install -y jekyll`
- `bundle install` *(fails: nokogiri requires older Ruby)*


------
https://chatgpt.com/codex/tasks/task_e_683f5ad074bc832c94da1638c8ef9f92